### PR TITLE
Support new multi-chain wallet functionality

### DIFF
--- a/cmd/magic-cli/main.go
+++ b/cmd/magic-cli/main.go
@@ -15,20 +15,20 @@ import (
 
 func main() {
 	app := &cli.App{
-		Name: "magic-cli",
-		Usage: "command line utility to make requests to api and validate tokens",
+		Name:     "magic-cli",
+		Usage:    "command line utility to make requests to api and validate tokens",
 		Compiled: time.Now(),
 		Commands: []*cli.Command{
 			{
-				Name: "token",
+				Name:    "token",
 				Aliases: []string{"t"},
-				Usage: "magic-cli token [decode|validate] --did <DID token>",
+				Usage:   "magic-cli token [decode|validate] --did <DID token>",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "decode",
 						Usage: "magic-cli token decode --did <DID token>",
 						Flags: []cli.Flag{
-							&cli.StringFlag {
+							&cli.StringFlag{
 								Name:  "did",
 								Usage: "Did token which must be decoded",
 							},
@@ -39,7 +39,7 @@ func main() {
 						Name:  "validate",
 						Usage: "magic-cli token validate --did <DID token>",
 						Flags: []cli.Flag{
-							&cli.StringFlag {
+							&cli.StringFlag{
 								Name:  "did",
 								Usage: "Did token which must be validated",
 							},
@@ -49,11 +49,11 @@ func main() {
 				},
 			},
 			{
-				Name: "user",
+				Name:    "user",
 				Aliases: []string{"u"},
-				Usage: "magic-cli -s <secret> user --did <DID token>",
+				Usage:   "magic-cli -s <secret> user --did <DID token>",
 				Flags: []cli.Flag{
-					&cli.StringFlag {
+					&cli.StringFlag{
 						Name:  "did",
 						Usage: "Did token used for user info receiving",
 					},
@@ -62,7 +62,7 @@ func main() {
 			},
 		},
 		Flags: []cli.Flag{
-			&cli.StringFlag {
+			&cli.StringFlag{
 				Name:    "secret",
 				Usage:   "Secret token which will be used for making request to backend api",
 				Aliases: []string{"s"},
@@ -70,7 +70,6 @@ func main() {
 			},
 		},
 	}
-
 
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)

--- a/error.go
+++ b/error.go
@@ -3,7 +3,7 @@ package magic
 import (
 	"encoding/json"
 	"net/http"
-	
+
 	"github.com/go-resty/resty/v2"
 )
 

--- a/magic.go
+++ b/magic.go
@@ -33,7 +33,7 @@ type Response struct {
 
 // NewDefaultClient creates backend client with default configuration of retries.
 func NewDefaultClient() *resty.Client {
-	return NewClientWithRetry(3, time.Second, 10 * time.Second)
+	return NewClientWithRetry(3, time.Second, 10*time.Second)
 }
 
 // NewClient creates new backend client with default api url.

--- a/token/did.go
+++ b/token/did.go
@@ -148,8 +148,9 @@ func signHash(data []byte) common.Hash {
 //
 // Note, this function is compatible with eth_sign and personal_sign. As such it recovers
 // the address of:
-//   hash = Keccak256Hash("\x19${byteVersion}Ethereum Signed Message:\n${message length}${message}")
-//   addr = ecRecover(hash, signature)
+//
+//	hash = Keccak256Hash("\x19${byteVersion}Ethereum Signed Message:\n${message length}${message}")
+//	addr = ecRecover(hash, signature)
 func ecRecover(hash hexutil.Bytes, sig hexutil.Bytes) (common.Address, error) {
 	if len(sig) != 65 {
 		return common.Address{}, fmt.Errorf("Signature must be 65 bytes long")

--- a/token/did_test.go
+++ b/token/did_test.go
@@ -24,7 +24,7 @@ func TestDIDTokenDecode(t *testing.T) {
 	proof := "0xaa50be70729ca705ba7c8d00185c6f2da479d0fcde5311ca4ce5b1ba715c8a721c5" +
 		"f1948434f96ff577d7b2b6ad82d3dd5a2457fe6998b137ed9bc08d36e549c1b"
 
-	claim := Claim {
+	claim := Claim{
 		Iat: 1586764270,
 		Ext: 11173528500,
 		Nbf: 1586764270,

--- a/token/errors.go
+++ b/token/errors.go
@@ -6,8 +6,8 @@ var (
 	ErrNotValidPublicAddr = &DIDTokenError{errors.New("Invalid public address format.")}
 	ErrNotValidProof      = &DIDTokenError{errors.New("Signature mismatch between 'proof' and 'claim'. Please " +
 		"generate a new token with an intended issuer.")}
-	ErrExpired            = &DIDTokenError{errors.New("Given DID token has expired. Please generate a new one.")}
-	ErrNbfExpired         = &DIDTokenError{errors.New("Given DID token cannot be used at this time. Please " +
+	ErrExpired    = &DIDTokenError{errors.New("Given DID token has expired. Please generate a new one.")}
+	ErrNbfExpired = &DIDTokenError{errors.New("Given DID token cannot be used at this time. Please " +
 		"check the 'nbf' field and regenerate a new token with a suitable value.")}
 )
 

--- a/user.go
+++ b/user.go
@@ -2,6 +2,8 @@ package magic
 
 import (
 	"encoding/json"
+
+	"github.com/magiclabs/magic-admin-go/wallet"
 )
 
 type User interface {
@@ -9,15 +11,26 @@ type User interface {
 	GetMetadataByPublicAddress(pubAddr string) (*UserInfo, error)
 	GetMetadataByToken(didToken string) (*UserInfo, error)
 
+	GetMetadataByIssuerAndWallet(issuer string, walletType wallet.Type) (*UserInfo, error)
+	GetMetadataByPublicAddressAndWallet(pubAddr string, walletType wallet.Type) (*UserInfo, error)
+	GetMetadataByTokenAndWallet(didToken string, walletType wallet.Type) (*UserInfo, error)
+
 	LogoutByIssuer(issuer string) error
 	LogoutByPublicAddress(pubAddr string) error
 	LogoutByToken(didToken string) error
 }
 
 type UserInfo struct {
-	Email         string `json:"email"`
-	Issuer        string `json:"issuer"`
+	Email         string    `json:"email"`
+	Issuer        string    `json:"issuer"`
+	PublicAddress string    `json:"public_address"`
+	Wallets       *[]Wallet `json:"wallets,omitempty"`
+}
+
+type Wallet struct {
+	Network       string `json:"network"`
 	PublicAddress string `json:"public_address"`
+	Type          string `json:"wallet_type"`
 }
 
 func (m *UserInfo) String() string {

--- a/user/client.go
+++ b/user/client.go
@@ -2,14 +2,16 @@ package user
 
 import (
 	"fmt"
+
 	"github.com/go-resty/resty/v2"
 
 	"github.com/magiclabs/magic-admin-go"
 	"github.com/magiclabs/magic-admin-go/token"
+	"github.com/magiclabs/magic-admin-go/wallet"
 )
 
 const (
-	userInfoV1 = "/v1/admin/auth/user/get"
+	userInfoV1   = "/v1/admin/auth/user/get"
 	userLogoutV2 = "/v2/admin/auth/user/logout"
 )
 
@@ -26,14 +28,57 @@ func NewUserClient(secret string, client *resty.Client) magic.User {
 	}
 }
 
+// GetMetadataByIssuerAndWallet returns metadata by issuer and wallet type.
+func (u *Client) GetMetadataByIssuerAndWallet(issuer string, walletType wallet.Type) (*magic.UserInfo, error) {
+	return u.getMetadataByIssuer(issuer, walletType)
+}
+
+// GetMetadataByPublicAddressAndWallet returns metadata by public address and wallet type.
+func (u *Client) GetMetadataByPublicAddressAndWallet(pubAddr string, walletType wallet.Type) (*magic.UserInfo, error) {
+	return u.getMetadataByIssuer(fmt.Sprintf("did:ethr:%s", pubAddr), walletType)
+}
+
+// GetMetadataByTokenAndWallet returns metadata by DID token with decoding and validating it.
+func (u *Client) GetMetadataByTokenAndWallet(didToken string, walletType wallet.Type) (*magic.UserInfo, error) {
+	tk, err := token.NewToken(didToken)
+	if err != nil {
+		return nil, err
+	}
+	if err := tk.Validate(); err != nil {
+		return nil, err
+	}
+
+	return u.getMetadataByIssuer(tk.GetIssuer(), walletType)
+}
+
 // GetMetadataByIssuer returns metadata by issuer.
 func (u *Client) GetMetadataByIssuer(issuer string) (*magic.UserInfo, error) {
+	return u.GetMetadataByIssuerAndWallet(issuer, wallet.NONE)
+}
+
+// GetMetadataByPublicAddress returns metadata by public address.
+func (u *Client) GetMetadataByPublicAddress(pubAddr string) (*magic.UserInfo, error) {
+	return u.GetMetadataByPublicAddressAndWallet(pubAddr, wallet.NONE)
+}
+
+// GetMetadataByToken returns metadata by DID token with decoding and validating it.
+func (u *Client) GetMetadataByToken(didToken string) (*magic.UserInfo, error) {
+	return u.GetMetadataByTokenAndWallet(didToken, wallet.NONE)
+}
+
+// getMetadataByIssuer helper method to return metadata by issuer and wallet type.
+func (u *Client) getMetadataByIssuer(issuer string, walletType wallet.Type) (*magic.UserInfo, error) {
 	meta := new(magic.UserInfo)
 	respData := new(magic.Response)
 	respData.Data = meta
+	queryParams := map[string]string{"issuer": issuer}
+
+	if walletType != wallet.NONE {
+		queryParams["wallet_type"] = string(walletType)
+	}
 
 	r, err := u.client.R().
-		SetQueryParams(map[string]string{"issuer": issuer}).
+		SetQueryParams(queryParams).
 		SetHeader(magic.APISecretHeader, u.secret).
 		SetResult(respData).
 		Get(userInfoV1)
@@ -45,24 +90,6 @@ func (u *Client) GetMetadataByIssuer(issuer string) (*magic.UserInfo, error) {
 	}
 
 	return meta, nil
-}
-
-// GetMetadataByPublicAddress returns metadata by public address.
-func (u *Client) GetMetadataByPublicAddress(pubAddr string) (*magic.UserInfo, error) {
-	return u.GetMetadataByIssuer(fmt.Sprintf("did:ethr:%s", pubAddr))
-}
-
-// GetMetadataByToken returns metadata by DID token with decoding and validating it.
-func (u *Client) GetMetadataByToken(didToken string) (*magic.UserInfo, error) {
-	tk, err := token.NewToken(didToken)
-	if err != nil {
-		return nil, err
-	}
-	if err := tk.Validate(); err != nil {
-		return nil, err
-	}
-
-	return u.GetMetadataByIssuer(tk.GetIssuer())
 }
 
 // LogoutByIssuer logout user from magic.link service by issuer.

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/magiclabs/magic-admin-go"
+	"github.com/magiclabs/magic-admin-go/wallet"
 )
 
 const testDIDToken = "WyIweGFhNTBiZTcwNzI5Y2E3MDViYTdjOGQwMDE4NWM2ZjJkYTQ3OWQwZm" +
@@ -42,6 +43,25 @@ func TestUserGetMetadata(t *testing.T) {
 	assert.Equal(t, "user@email.com", meta.Email)
 	assert.Equal(t, "did:ethr:0x4B73C58370AEfcEf86A6021afCDe5673511376B2", meta.Issuer)
 	assert.Equal(t, "0x4B73C58370AEfcEf86A6021afCDe5673511376B2", meta.PublicAddress)
+}
+
+func TestUserGetMetadataWithWallet(t *testing.T) {
+	srv := createServerSuccess(t)
+	defer srv.Close()
+
+	// Replace host url to test one.
+	client := magic.NewDefaultClient()
+	client.SetHostURL(srv.URL)
+
+	uClient := NewUserClient(testSecret, client)
+
+	meta, err := uClient.GetMetadataByTokenAndWallet(testDIDToken, wallet.ETH)
+	require.NoError(t, err, "can't create new token")
+
+	assert.Equal(t, "user@email.com", meta.Email)
+	assert.Equal(t, "did:ethr:0x4B73C58370AEfcEf86A6021afCDe5673511376B2", meta.Issuer)
+	assert.Equal(t, "0x4B73C58370AEfcEf86A6021afCDe5673511376B2", meta.PublicAddress)
+	assert.NotNil(t, meta.Wallets)
 }
 
 func TestUserGetMetadataWrongSecret(t *testing.T) {
@@ -139,7 +159,7 @@ func createServerSuccess(t *testing.T) *httptest.Server {
 						Issuer:        "did:ethr:0x4B73C58370AEfcEf86A6021afCDe5673511376B2",
 						PublicAddress: "0x4B73C58370AEfcEf86A6021afCDe5673511376B2",
 					},
-					Status:    "ok",
+					Status: "ok",
 				}
 				data, err := json.Marshal(resp)
 				require.NoError(t, err, "can't marshal test data")

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,0 +1,28 @@
+package wallet
+
+type Type string
+
+const (
+	ETH      Type = "ETH"
+	HARMONY       = "HARMONY"
+	ICON          = "ICON"
+	FLOW          = "FLOW"
+	TEZOS         = "TEZOS"
+	ZILLIQA       = "ZILLIQA"
+	POLKADOT      = "POLKADOT"
+	SOLANA        = "SOLANA"
+	AVAX          = "AVAX"
+	ALGOD         = "ALGOD"
+	COSMOS        = "COSMOS"
+	CELO          = "CELO"
+	BITCOIN       = "BITCOIN"
+	NEAR          = "NEAR"
+	HELIUM        = "HELIUM"
+	CONFLUX       = "CONFLUX"
+	TERRA         = "TERRA"
+	TAQUITO       = "TAQUITO"
+	ED            = "ED"
+	HEDERA        = "HEDERA"
+	ANY           = "ANY"
+	NONE          = "NONE"
+)


### PR DESCRIPTION
The current implementation of `magic-admin-go` for metadata retrieval returns the Ethereum public_address. 

We are adding functionality to query wallet(s) for any chain tied to the end-user.

Example (queries all Solana wallets created for the user if applicable):
`
meta, err := magicClient.GetMetadataByTokenAndWallet(testDIDToken, wallet.SOLANA)
`

Example (queries all wallets created for the user if applicable):
`
meta, err := magicClient.GetMetadataByTokenAndWallet(testDIDToken, wallet.ANY)
`

Please see supported wallet types in `wallet/wallet.go`.