### PR TITLE
Validate aud using client id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@
 
 ## `1.0.0` - 07/05/2023
 
-[//]: # ()
-[//]: # (### Added)
-
-[//]: # ()
-[//]: # (- PR-#11: Add Magic Connect Admin SDK support for Token Validation )
-
-[//]: # (    - [Security Enhancement]: Validate `aud` using Magic client ID.)
-
-[//]: # (    - Pull client ID from Magic servers in client constructor.)
-
 ### Summary
 - 🚀 **Added:** Magic Connect developers can now use the Admin SDK to validate DID tokens.
 - ⚠️ **Changed:** After creating the Magic instance, it is now necessary to call a new initialize method for Magic Connect developers that want to utilize the Admin SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,113 @@
-## Upcoming Changes
+# Changelog
 
-#### Fixed
 
-- <PR-#ISSUE> ...
+## `1.0.0` - 07/05/2023
+
+[//]: # ()
+[//]: # (### Added)
+
+[//]: # ()
+[//]: # (- PR-#11: Add Magic Connect Admin SDK support for Token Validation )
+
+[//]: # (    - [Security Enhancement]: Validate `aud` using Magic client ID.)
+
+[//]: # (    - Pull client ID from Magic servers in client constructor.)
+
+### Summary
+- 🚀 **Added:** Magic Connect developers can now use the Admin SDK to validate DID tokens.
+- ⚠️ **Changed:** After creating the Magic instance, it is now necessary to call a new initialize method for Magic Connect developers that want to utilize the Admin SDK.
+- 🛡️ **Security:** Additional validation of `aud` (client ID) is now being done during initialization of the SDK.
+
+### Developer Notes
+
+#### 🚀 Added
+
+Magic Connect developers can now use the Admin SDK to validate DID tokens.
+
+**Details**
+There is full support for all `Token` SDK methods for MC. This is intended to be used with client side [`magic-js`](#) SDK which will now emit an `id-token-created` event with a DID token upon login via the [`connectWithUI`](#) method.
+
+This functionality is replicated on our other SDKs on Python and Ruby.
+
+#### ⚠️ Changed
+
+To validate tokens, a Magic clientId is now required in the `validate` method. 
+Initializing the client will pull clientId from the Magic servers.
+Alternatively, you can get client ID from the magic dashboard and pass it in directly.
+
+**Previous Version**
+```golang
+package main
+
+import (
+    "log"
+    "fmt"
+
+    "github.com/magiclabs/magic-admin-go/token"
+)
+
+func main() {
+	tk, err := token.NewToken("<DID_TOKEN>")
+    if err != nil {
+        log.Fatalf("DID token is malformed: %s", err.Error())
+    }
+    
+    if err := tk.Validate(); err != nil {
+        log.Fatalf("DID token is invalid: %v", err)
+    }
+
+    fmt.Println(tk.GetClaim())
+    fmt.Println(tk.GetProof())
+}
+```
+
+**New Version**
+```golang
+package main
+
+import (
+    "log"
+    "fmt"
+
+	"github.com/magiclabs/magic-admin-go/client"
+    "github.com/magiclabs/magic-admin-go/token"
+)
+
+func main() {
+
+	c, err := client.New("<YOUR_API_SECRET_KEY>", magic.NewDefaultClient())
+
+	if err != nil {
+		log.Fatalf("Unable to initialize client: %s", err.Error())
+	}
+	
+	tk, err := token.NewToken("<DID_TOKEN>")
+    if err != nil {
+        log.Fatalf("DID token is malformed: %s", err.Error())
+    }
+    
+    if err := tk.Validate(c.ClientInfo.ClientId); err != nil {
+        log.Fatalf("DID token is invalid: %v", err)
+    }
+
+    fmt.Println(tk.GetClaim())
+    fmt.Println(tk.GetProof())
+}
+```
+
+### 🛡️ Security
+
+#### Client ID Validation
+
+Additional validation of `aud` (client ID) is now being done while validating DID tokens. This is for both Magic Connect and Magic Auth developers.
+
+
+### 🚨 Breaking
+
+* Client initialization now makes a call to Magic servers to fetch `clientId` and will now return an error if there is an issue communicating to Magic's servers. 
+* The `validate` method now takes in a clientId and validates it against the `aud` field in the DID token.
+
+## `0.2.0`
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ USAGE:
    magic-cli [global options] command [command options] [arguments...]
 
 COMMANDS:
-   token, t   magic-cli token [decode|validate] --did <DID token>
+   token, t   magic-cli token [decode|validate] --did <DID token> [--clientId <Magic Client ID>]
    user, u    magic-cli -s <secret> user --did <DID token>
    help, h    Shows a list of commands or help for one command
 
@@ -81,7 +81,7 @@ import (
 )
 
 func main() {
-    m := client.New("<YOUR_API_SECRET_KEY>", magic.NewDefaultClient())
+    m, err := client.New("<YOUR_API_SECRET_KEY>", magic.NewDefaultClient())
     userInfo, err := m.User.GetMetadataByToken("<DID_TOKEN>")
     if err != nil {
         log.Fatalf("Error: %s", err.Error())
@@ -99,16 +99,24 @@ import (
     "log"
     "fmt"
 
+	"github.com/magiclabs/magic-admin-go/client"
     "github.com/magiclabs/magic-admin-go/token"
 )
 
 func main() {
-    tk, err := token.NewToken("<DID_TOKEN>")
+
+	c, err := client.New("<YOUR_API_SECRET_KEY>", magic.NewDefaultClient())
+
+	if err != nil {
+		log.Fatalf("Unable to initialize client: %s", err.Error())
+	}
+	
+	tk, err := token.NewToken("<DID_TOKEN>")
     if err != nil {
         log.Fatalf("DID token is malformed: %s", err.Error())
     }
     
-    if err := tk.Validate(); err != nil {
+    if err := tk.Validate(c.ClientInfo.ClientId); err != nil {
         log.Fatalf("DID token is invalid: %v", err)
     }
 

--- a/client/api.go
+++ b/client/api.go
@@ -7,12 +7,41 @@ import (
 	"github.com/magiclabs/magic-admin-go/user"
 )
 
+const (
+	clientInfoV1 = "/v1/admin/client/get"
+)
+
 type API struct {
-	User magic.User
+	User       magic.User
+	ClientInfo magic.ClientInfo
 }
 
-func New(secret string, client *resty.Client) *API {
-	return &API{
-		User: user.NewUserClient(secret, client),
+func New(secret string, client *resty.Client) (*API, error) {
+	clientInfo, err := getClientInfo(secret, client)
+	if err != nil {
+		return nil, err
 	}
+	return &API{
+		User:       user.NewUserClient(secret, clientInfo.ClientId, client),
+		ClientInfo: *clientInfo,
+	}, nil
+}
+
+func getClientInfo(secret string, client *resty.Client) (*magic.ClientInfo, error) {
+	meta := new(magic.ClientInfo)
+	respData := new(magic.Response)
+	respData.Data = meta
+
+	r, err := client.R().
+		SetHeader(magic.APISecretHeader, secret).
+		SetResult(respData).
+		Get(clientInfoV1)
+	if err != nil {
+		return nil, &magic.APIConnectionError{Err: err}
+	}
+	if r.IsError() {
+		return nil, magic.WrapError(r, r.Error().(*magic.Error))
+	}
+
+	return meta, nil
 }

--- a/token/did.go
+++ b/token/did.go
@@ -98,7 +98,7 @@ func (t *Token) GetNbfGracePeriod() int64 {
 
 // Validates DID token by recovering public key using signature data and the hash
 // of the claim message.
-func (t *Token) Validate() error {
+func (t *Token) Validate(clientId string) error {
 	jsonClaim, err := json.Marshal(t.claim)
 	if err != nil {
 		return &DIDTokenError{err}
@@ -133,6 +133,10 @@ func (t *Token) Validate() error {
 	}
 	if now < t.GetNbfGracePeriod() {
 		return ErrNbfExpired
+	}
+
+	if t.claim.Aud != clientId {
+		return ErrAudMismatch
 	}
 
 	return nil

--- a/token/did_test.go
+++ b/token/did_test.go
@@ -43,5 +43,5 @@ func TestDIDTokenDecode(t *testing.T) {
 	assert.Equal(t, proof, token.GetProof())
 	assert.Equal(t, issuer, token.GetIssuer())
 
-	assert.NoError(t, token.Validate(), "token is not valid")
+	assert.NoError(t, token.Validate("did:magic:731848cc-084e-41ff-bbdf-7f103817ea6b"), "token is not valid")
 }

--- a/token/errors.go
+++ b/token/errors.go
@@ -9,6 +9,8 @@ var (
 	ErrExpired    = &DIDTokenError{errors.New("Given DID token has expired. Please generate a new one.")}
 	ErrNbfExpired = &DIDTokenError{errors.New("Given DID token cannot be used at this time. Please " +
 		"check the 'nbf' field and regenerate a new token with a suitable value.")}
+	ErrAudMismatch = &DIDTokenError{errors.New("Audience does not match client ID. Please ensure your " +
+		"secret key matches the application which generated the DID token.")}
 )
 
 type DIDTokenError struct {

--- a/user.go
+++ b/user.go
@@ -27,6 +27,11 @@ type UserInfo struct {
 	Wallets       *[]Wallet `json:"wallets,omitempty"`
 }
 
+type ClientInfo struct {
+	ClientId string `json:"client_id"`
+	AppScope string `json:"app_scope"`
+}
+
 type Wallet struct {
 	Network       string `json:"network"`
 	PublicAddress string `json:"public_address"`

--- a/user/client.go
+++ b/user/client.go
@@ -16,15 +16,17 @@ const (
 )
 
 type Client struct {
-	secret string
-	client *resty.Client
+	secret        string
+	magicClientId string
+	client        *resty.Client
 }
 
 // NewUserClient constructor of user client api.
-func NewUserClient(secret string, client *resty.Client) magic.User {
+func NewUserClient(secret string, magicClientId string, client *resty.Client) magic.User {
 	return &Client{
-		secret: secret,
-		client: client,
+		secret:        secret,
+		magicClientId: magicClientId,
+		client:        client,
 	}
 }
 
@@ -44,7 +46,7 @@ func (u *Client) GetMetadataByTokenAndWallet(didToken string, walletType wallet.
 	if err != nil {
 		return nil, err
 	}
-	if err := tk.Validate(); err != nil {
+	if err := tk.Validate(u.magicClientId); err != nil {
 		return nil, err
 	}
 
@@ -119,7 +121,7 @@ func (u *Client) LogoutByToken(didToken string) error {
 	if err != nil {
 		return err
 	}
-	if err := tk.Validate(); err != nil {
+	if err := tk.Validate(u.magicClientId); err != nil {
 		return err
 	}
 

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -27,6 +27,8 @@ const testDIDToken = "WyIweGFhNTBiZTcwNzI5Y2E3MDViYTdjOGQwMDE4NWM2ZjJkYTQ3OWQwZm
 
 const testSecret = "sk_test_E123E4567E8901D2"
 
+const testClientId = "did:magic:731848cc-084e-41ff-bbdf-7f103817ea6b"
+
 var (
 	testDataMagicWallets = []magic.Wallet{
 		{
@@ -56,7 +58,7 @@ func TestUserGetMetadata(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient(testSecret, client)
+	uClient := NewUserClient(testSecret, testClientId, client)
 
 	meta, err := uClient.GetMetadataByToken(testDIDToken)
 	require.NoError(t, err, "can't create new token")
@@ -74,7 +76,7 @@ func TestUserGetMetadataWithWallet(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient(testSecret, client)
+	uClient := NewUserClient(testSecret, testClientId, client)
 
 	meta, err := uClient.GetMetadataByTokenAndWallet(testDIDToken, wallet.SOLANA)
 	require.NoError(t, err, "can't create new token")
@@ -95,7 +97,7 @@ func TestUserGetMetadataWithAny(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient(testSecret, client)
+	uClient := NewUserClient(testSecret, testClientId, client)
 
 	meta, err := uClient.GetMetadataByTokenAndWallet(testDIDToken, wallet.ANY)
 	require.NoError(t, err, "can't create new token")
@@ -116,7 +118,7 @@ func TestUserGetMetadataWrongSecret(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient("wrong_secret", client)
+	uClient := NewUserClient("wrong_secret", testClientId, client)
 
 	_, err := uClient.GetMetadataByToken(testDIDToken)
 	require.Error(t, err, "server must return error")
@@ -132,7 +134,7 @@ func TestUserGetMetadataBackendFailure(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient("wrong_secret", client)
+	uClient := NewUserClient("wrong_secret", testClientId, client)
 
 	_, err := uClient.GetMetadataByToken(testDIDToken)
 	require.Error(t, err, "server must return error")
@@ -148,7 +150,7 @@ func TestUserLogout(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient(testSecret, client)
+	uClient := NewUserClient(testSecret, testClientId, client)
 
 	err := uClient.LogoutByToken(testDIDToken)
 	require.NoError(t, err, "can't logout user by DID token")
@@ -162,7 +164,7 @@ func TestUserLogoutBackendFailure(t *testing.T) {
 	client := magic.NewDefaultClient()
 	client.SetHostURL(srv.URL)
 
-	uClient := NewUserClient("wrong_secret", client)
+	uClient := NewUserClient("wrong_secret", testClientId, client)
 
 	err := uClient.LogoutByToken(testDIDToken)
 	require.Error(t, err, "server must return error")


### PR DESCRIPTION
## Changed:
* Validate aud using client ID
* Fetch client ID from secret key when initializing client.

## Tested:
```
	api, _ := New("SECRET KEY", magic.NewDefaultClient())
	tk, _ := token.NewToken("DID TOKEN")
	validate_err := tk.Validate(api.ClientInfo.ClientId)
	assert.Equal(t, validate_err, nil)
	validate_err2 := tk.Validate("diffClientId")
	assert.NotEqual(t, validate_err2, nil)
```